### PR TITLE
Fix dependency conflict between date-fns and react-day-picker

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm run build --legacy-peer-deps"
   publish = ".next"
   environment = { NODE_VERSION = "18" }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
-    "date-fns": "^4.1.0",
+    "date-fns": "^2.28.0 || ^3.0.0",
     "embla-carousel-react": "^8.5.1",
     "eslint-plugin-react-hooks": "^5.0.0",
     "framer-motion": "^11.13.0",


### PR DESCRIPTION
Fixes #1

Resolve npm dependency conflict between `date-fns` and `react-day-picker`.

* Update `date-fns` version to `^2.28.0 || ^3.0.0` in `frontend/package.json`.
* Add `--legacy-peer-deps` flag to the build command in `frontend/netlify.toml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/4cecoder/salesflow/pull/2?shareId=65cd74c6-a6b3-488e-b845-0823956e9d99).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build command to improve dependency handling during the build process.
	- Modified the version constraint for the `date-fns` package to enhance compatibility with earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->